### PR TITLE
fix: use rust_verify directly instead of verus wrapper

### DIFF
--- a/verus/private/repo.bzl
+++ b/verus/private/repo.bzl
@@ -14,10 +14,16 @@ load("@rules_verus//verus:toolchain.bzl", "verus_toolchain_info")
 
 package(default_visibility = ["//visibility:public"])
 
-# Verus verifier binary
+# Verus wrapper binary (kept for reference; rust_verify is preferred)
 filegroup(
     name = "verus_bin",
     srcs = ["verus"],
+)
+
+# rust_verify binary (the actual rustc driver — preferred over verus wrapper)
+filegroup(
+    name = "rust_verify_bin",
+    srcs = ["rust_verify"],
 )
 
 # Z3 SMT solver
@@ -38,6 +44,18 @@ filegroup(
     srcs = ["libvstd.rlib"],
 )
 
+# Compiled builtin rlib
+filegroup(
+    name = "builtin_rlib",
+    srcs = ["libverus_builtin.rlib"],
+)
+
+# Compiled builtin_macros proc-macro (platform-dependent extension)
+filegroup(
+    name = "builtin_macros_dylib",
+    srcs = glob(["libverus_builtin_macros.*"]),
+)
+
 # Builtin crate sources
 filegroup(
     name = "builtin_srcs",
@@ -53,10 +71,13 @@ filegroup(
 verus_toolchain_info(
     name = "verus_toolchain_info",
     verus = ":verus_bin",
+    rust_verify = ":rust_verify_bin",
     z3 = ":z3_bin",
     vstd = ":vstd_files",
     vstd_rlib = ":vstd_rlib",
     builtin = ":builtin_srcs",
+    builtin_rlib = ":builtin_rlib",
+    builtin_macros_dylib = ":builtin_macros_dylib",
     version = "{version}",
 )
 

--- a/verus/toolchain.bzl
+++ b/verus/toolchain.bzl
@@ -4,11 +4,14 @@
 VerusToolchainInfo = provider(
     doc = "Information about a Verus verification toolchain",
     fields = {
-        "verus": "File: The verus verifier binary",
+        "verus": "File: The verus wrapper binary (kept for compatibility)",
+        "rust_verify": "File: The rust_verify binary (preferred verifier driver)",
         "z3": "File: The Z3 SMT solver binary",
         "vstd": "File: The vstd pre-verified standard library (vstd.vir)",
         "vstd_rlib": "File: The vstd compiled library (libvstd.rlib)",
         "builtin": "depset of File: The builtin crate sources",
+        "builtin_rlib": "File: The builtin compiled library (libverus_builtin.rlib)",
+        "builtin_macros_dylib": "File: The builtin_macros proc-macro library",
         "version": "String: Verus version",
     },
 )
@@ -17,6 +20,9 @@ def _verus_toolchain_info_impl(ctx):
     """Create a VerusToolchainInfo provider for the toolchain."""
     verus_files = ctx.files.verus
     verus = verus_files[0] if verus_files else None
+
+    rust_verify_files = ctx.files.rust_verify
+    rust_verify = rust_verify_files[0] if rust_verify_files else None
 
     z3_files = ctx.files.z3
     z3 = z3_files[0] if z3_files else None
@@ -31,12 +37,21 @@ def _verus_toolchain_info_impl(ctx):
     vstd_rlib_files = ctx.files.vstd_rlib
     vstd_rlib = vstd_rlib_files[0] if vstd_rlib_files else None
 
+    builtin_rlib_files = ctx.files.builtin_rlib
+    builtin_rlib = builtin_rlib_files[0] if builtin_rlib_files else None
+
+    builtin_macros_files = ctx.files.builtin_macros_dylib
+    builtin_macros_dylib = builtin_macros_files[0] if builtin_macros_files else None
+
     verus_info = struct(
         verus = verus,
+        rust_verify = rust_verify,
         z3 = z3,
         vstd = vstd,
         vstd_rlib = vstd_rlib,
         builtin = depset(ctx.files.builtin),
+        builtin_rlib = builtin_rlib,
+        builtin_macros_dylib = builtin_macros_dylib,
         version = ctx.attr.version,
     )
 
@@ -51,7 +66,11 @@ verus_toolchain_info = rule(
     attrs = {
         "verus": attr.label(
             allow_files = True,
-            doc = "The verus verifier binary",
+            doc = "The verus wrapper binary",
+        ),
+        "rust_verify": attr.label(
+            allow_files = True,
+            doc = "The rust_verify binary (modified rustc driver)",
         ),
         "z3": attr.label(
             allow_files = True,
@@ -68,6 +87,14 @@ verus_toolchain_info = rule(
         "builtin": attr.label(
             allow_files = True,
             doc = "The builtin crate sources",
+        ),
+        "builtin_rlib": attr.label(
+            allow_files = True,
+            doc = "The builtin compiled rlib (libverus_builtin.rlib)",
+        ),
+        "builtin_macros_dylib": attr.label(
+            allow_files = True,
+            doc = "The builtin_macros proc-macro library",
         ),
         "version": attr.string(
             doc = "Verus version string",


### PR DESCRIPTION
## Summary
- The `verus` wrapper binary fails to locate `builtin`/`builtin_macros` crates in sandboxed and non-standard environments
- Switch to invoking `rust_verify` (the actual rustc driver) directly with explicit `--extern` flags
- Adds `rust_verify`, `builtin_rlib`, and `builtin_macros_dylib` to the toolchain provider

## Changes
- **`verus/private/repo.bzl`**: Added filegroups for `rust_verify`, `libverus_builtin.rlib`, and `libverus_builtin_macros.*`
- **`verus/toolchain.bzl`**: Added `rust_verify`, `builtin_rlib`, `builtin_macros_dylib` fields to the provider
- **`verus/private/verus.bzl`**: Rewrote both `verus_library` and `verus_test` to use `rust_verify` with explicit `--extern` flags, proper sysroot detection, and `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` setup

## Test plan
- [ ] Run `bazel test //kiln-foundation/src/verus_proofs:static_vec_verify` in Kiln repo pointing to this commit
- [ ] Verify "13 verified, 0 errors" output from rust_verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)