### PR TITLE
fix: use correct Rust sysroot for rust_verify

### DIFF
--- a/verus/private/verus.bzl
+++ b/verus/private/verus.bzl
@@ -133,6 +133,9 @@ def _verus_verify_impl(ctx):
             vstd_rlib = vstd_rlib.path,
         )
 
+    # Get the Rust toolchain version for sysroot detection
+    rust_toolchain = verus_info.rust_toolchain
+
     script_content = """\
 #!/bin/bash
 set -euo pipefail
@@ -144,8 +147,16 @@ for p in "$HOME/.cargo/bin" "$HOME/.rustup/shims" "/usr/local/bin"; do
     [ -d "$p" ] && export PATH="$p:$PATH"
 done
 
-SYSROOT=$(rustc --print sysroot 2>/dev/null || true)
-if [ -z "$SYSROOT" ]; then
+# rust_verify is compiled against a specific Rust toolchain version.
+# Use that exact version for the sysroot to get matching librustc_driver.
+RUST_TC="{rust_toolchain}"
+if [ -n "$RUST_TC" ]; then
+    SYSROOT=$(rustc +"$RUST_TC" --print sysroot 2>/dev/null || true)
+fi
+if [ -z "${{SYSROOT:-}}" ]; then
+    SYSROOT=$(rustc --print sysroot 2>/dev/null || true)
+fi
+if [ -z "${{SYSROOT:-}}" ]; then
     echo "ERROR: Cannot determine Rust sysroot. Is rustc installed?" >&2
     exit 1
 fi
@@ -165,6 +176,7 @@ export PATH="$(dirname "{z3}"):$PATH"
 """.format(
         rust_verify = rust_verify.path,
         z3 = z3.path,
+        rust_toolchain = rust_toolchain,
         builtin_extern_flags = builtin_extern_flags,
         flags = " ".join(all_flags),
         stamp = stamp.path,
@@ -293,6 +305,9 @@ def _verus_test_impl(ctx):
             vstd_rlib = vstd_rlib.short_path,
         )
 
+    # Get the Rust toolchain version for sysroot detection
+    rust_toolchain = verus_info.rust_toolchain
+
     # Create a test runner script
     script_content = """\
 #!/bin/bash
@@ -305,9 +320,18 @@ for p in "$HOME/.cargo/bin" "$HOME/.rustup/shims" "/usr/local/bin"; do
     [ -d "$p" ] && export PATH="$p:$PATH"
 done
 
-SYSROOT=$(rustc --print sysroot 2>/dev/null || true)
-if [ -z "$SYSROOT" ]; then
-    echo "ERROR: Cannot determine Rust sysroot. Is rustc installed?" >&2
+# rust_verify is compiled against a specific Rust toolchain version.
+# Use that exact version for the sysroot to get matching librustc_driver.
+RUST_TC="{rust_toolchain}"
+if [ -n "$RUST_TC" ]; then
+    SYSROOT=$(rustc +"$RUST_TC" --print sysroot 2>/dev/null || true)
+fi
+if [ -z "${{SYSROOT:-}}" ]; then
+    SYSROOT=$(rustc --print sysroot 2>/dev/null || true)
+fi
+if [ -z "${{SYSROOT:-}}" ]; then
+    echo "ERROR: Cannot determine Rust sysroot. Is rustc/rustup installed?" >&2
+    echo "rust_verify requires Rust toolchain $RUST_TC" >&2
     exit 1
 fi
 
@@ -328,6 +352,7 @@ echo "=== Verus Verification Test ==="
 echo "Crate: {crate_name}"
 echo "Source: $SRC"
 echo "Verifier: $RUST_VERIFY"
+echo "Rust sysroot: $SYSROOT"
 echo ""
 
 "$RUST_VERIFY" --edition=2021 --crate-type lib --sysroot "$SYSROOT" \
@@ -348,6 +373,7 @@ exit $STATUS
         z3 = z3.short_path,
         src = crate_root.short_path,
         crate_name = crate_name,
+        rust_toolchain = rust_toolchain,
         builtin_extern_flags = builtin_extern_flags,
         flags = " ".join(all_flags),
     )
@@ -393,5 +419,8 @@ verus_test = rule(
     },
     toolchains = ["@rules_verus//verus:toolchain_type"],
     test = True,
+    # rust_verify requires access to host rustc/rustup for sysroot detection.
+    # local = True prevents test sandboxing so $HOME/.rustup is accessible.
+    local = True,
     doc = "Test target that runs Verus verification. Passes if all proofs verify.",
 )

--- a/verus/toolchain.bzl
+++ b/verus/toolchain.bzl
@@ -13,6 +13,7 @@ VerusToolchainInfo = provider(
         "builtin_rlib": "File: The builtin compiled library (libverus_builtin.rlib)",
         "builtin_macros_dylib": "File: The builtin_macros proc-macro library",
         "version": "String: Verus version",
+        "rust_toolchain": "String: Rust toolchain version that rust_verify was built against (e.g., '1.93.0')",
     },
 )
 
@@ -53,6 +54,7 @@ def _verus_toolchain_info_impl(ctx):
         builtin_rlib = builtin_rlib,
         builtin_macros_dylib = builtin_macros_dylib,
         version = ctx.attr.version,
+        rust_toolchain = ctx.attr.rust_toolchain,
     )
 
     return [
@@ -98,6 +100,10 @@ verus_toolchain_info = rule(
         ),
         "version": attr.string(
             doc = "Verus version string",
+        ),
+        "rust_toolchain": attr.string(
+            default = "",
+            doc = "Rust toolchain version that rust_verify was built against (e.g., '1.93.0')",
         ),
     },
     doc = "Provides Verus toolchain information",


### PR DESCRIPTION
## Summary
- `rust_verify` is compiled against a specific Rust toolchain (e.g., 1.93.0) and needs that exact sysroot for `librustc_driver`
- Previous scripts used `rustc --print sysroot` which returns the default toolchain, causing `dyld` load failures
- Parse `version.json` from the Verus release to extract the required Rust version
- Use `rustc +{version} --print sysroot` for exact matching
- Add `local = True` to `verus_test` rule to prevent sandbox blocking `rustup` access

## Test plan
- [ ] Run `bazel test //kiln-foundation/src/verus_proofs:static_vec_verify` in Kiln repo
- [ ] Verify "13 verified, 0 errors" output

🤖 Generated with [Claude Code](https://claude.com/claude-code)