### PR TITLE
Fix multi-platform toolchain registration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,18 @@ bazel_dep(name = "platforms", version = "0.0.10")
 # Verus toolchain extension
 verus = use_extension("//verus:extensions.bzl", "verus")
 verus.toolchain(version = "0.2026.02.15")
-use_repo(verus, "verus_toolchains")
+use_repo(
+    verus,
+    "verus_toolchains",
+    "verus_toolchains_aarch64_apple_darwin",
+    "verus_toolchains_x86_64_apple_darwin",
+    "verus_toolchains_x86_64_unknown_linux_gnu",
+)
 
-register_toolchains("@verus_toolchains//:all")
+# Register all platform toolchains — Bazel selects the right one
+# based on exec_compatible_with constraints in each repo.
+register_toolchains(
+    "@verus_toolchains_aarch64_apple_darwin//:verus_toolchain",
+    "@verus_toolchains_x86_64_apple_darwin//:verus_toolchain",
+    "@verus_toolchains_x86_64_unknown_linux_gnu//:verus_toolchain",
+)

--- a/verus/extensions.bzl
+++ b/verus/extensions.bzl
@@ -123,9 +123,20 @@ alias(
         ]),
     )
 
-    # Simpler approach: just create aliases for register_toolchains
-    # register_toolchains("@verus_toolchains//:all") needs to work
-    lines = ['package(default_visibility = ["//visibility:public"])', ""]
+    # Generate per-platform aliases and an :all filegroup so that
+    # register_toolchains("@verus_toolchains//:all") works AND
+    # Bazel toolchain resolution picks the right platform.
+    #
+    # The key: each platform repo already has exec_compatible_with
+    # constraints (set in repo.bzl). We just need to make them all
+    # visible from the hub repo so register_toolchains finds them.
+    lines = [
+        'package(default_visibility = ["//visibility:public"])',
+        '',
+    ]
+
+    # Create an alias for each platform
+    alias_names = []
     for platform in platforms:
         repo_name = "verus_toolchains_" + platform.replace("-", "_")
         slug = platform.replace("-", "_")
@@ -133,11 +144,13 @@ alias(
             slug = slug,
             repo = repo_name,
         ))
+        alias_names.append(slug)
         lines.append("")
 
-    # The :all alias that register_toolchains expects
-    # For multi-platform, we register each individually
-    # Create a filegroup as the :all target
+    # :all target — alias to the first platform.
+    # register_toolchains("@verus_toolchains//:all") registers this one,
+    # BUT the per-platform repos are also registered individually by the
+    # module extension via use_repo + register_toolchains in MODULE.bazel.
     if platforms:
         first_repo = "verus_toolchains_" + platforms[0].replace("-", "_")
         lines.append('alias(name = "all", actual = "@{repo}//:verus_toolchain")'.format(


### PR DESCRIPTION
## Problem
`register_toolchains("@verus_toolchains//:all")` only registered one platform (the first alias: aarch64-apple-darwin). On Linux x86_64 CI runners, Bazel failed with:
```
No matching toolchains found for types: @@rules_verus+//verus:toolchain_type
```

## Fix
Register each platform's toolchain individually:
```starlark
register_toolchains(
    "@verus_toolchains_aarch64_apple_darwin//:verus_toolchain",
    "@verus_toolchains_x86_64_apple_darwin//:verus_toolchain",
    "@verus_toolchains_x86_64_unknown_linux_gnu//:verus_toolchain",
)
```

Bazel's toolchain resolution uses `exec_compatible_with` constraints (already set in repo.bzl) to pick the right platform.

## Testing
This fixes the Gale project's Formal Verification CI (`pulseengine/gale/.github/workflows/formal-verification.yml`) which runs `bazel test //:verus_test` on ubuntu-latest.