### PR TITLE
fix: bundle Rust nightly sysroot with Verus toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Bazel rules for [Verus](https://github.com/verus-lang/verus) SMT-backed Rust ver
 
 ```starlark
 bazel_dep(name = "rules_verus", version = "0.1.0")
-bazel_dep(name = "rules_rust", version = "0.65.0")  # or your project's version
 
 git_override(
     module_name = "rules_verus",
@@ -33,17 +32,8 @@ git_override(
     commit = "<latest-commit>",
 )
 
-# Register a Rust toolchain that includes the version Verus needs (1.93.0).
-# verus_library/verus_test resolve @rules_rust//rust:toolchain_type for the sysroot.
-rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
-rust.toolchain(
-    edition = "2021",
-    versions = ["1.93.0"],  # must match Verus's rust_verify (see extensions.bzl)
-)
-use_repo(rust, "rust_toolchains")
-register_toolchains("@rust_toolchains//:all")
-
-# Configure Verus toolchain
+# Configure Verus toolchain — automatically downloads Verus binaries
+# AND the matching Rust sysroot (no host rustup or rules_rust toolchain needed)
 verus = use_extension("@rules_verus//verus:extensions.bzl", "verus")
 verus.toolchain(version = "0.2026.02.15")
 use_repo(verus, "verus_toolchains")
@@ -308,19 +298,15 @@ verus_strip_test(
 
 ### Hermetic Rust Toolchain
 
-`verus_library` and `verus_test` resolve `@rules_rust//rust:toolchain_type` to get a hermetic
-Rust sysroot. **Consumers must register a Rust toolchain** that includes the version matching
-Verus's `rust_verify` binary (see `rust_version` in `_KNOWN_VERSIONS` in `extensions.bzl`).
+The Verus toolchain extension automatically downloads and bundles the matching Rust nightly
+sysroot (`librustc_driver`, `libstd`, etc.) alongside the Verus binaries. This means:
 
-For Verus 0.2026.02.15, this is Rust **1.93.0**. Add to your MODULE.bazel:
-
-```starlark
-rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
-rust.toolchain(versions = ["1.93.0"])
-```
-
-`rules_verus` declares `rules_rust >= 0.56.0` as a minimum — it does not pin a specific version
-or register toolchains, so it won't conflict with your project's existing `rules_rust` version.
+- **No host `rustup` required** — the sysroot is hermetically provisioned
+- **No `rules_rust` toolchain registration needed** — consumers don't need to know which nightly
+  Verus was built against
+- **Full sandbox support** — all files are available as Bazel inputs
+- **`rules_rust` is only needed for `verus_strip`** (building from source via `crate_universe`),
+  and uses a low minimum version (`>= 0.56.0`) to avoid conflicts
 
 ## License
 

--- a/verus/extensions.bzl
+++ b/verus/extensions.bzl
@@ -10,7 +10,7 @@ load("//verus/private:repo.bzl", "verus_release")
 _KNOWN_VERSIONS = {
     "0.2026.02.15": {
         "tag": "0.2026.02.15.61aa1bf",
-        "rust_version": "1.93.0",  # Rust toolchain version that rust_verify was built against
+        "rust_nightly": "2025-11-21",  # Nightly date for librustc_driver (auto-downloaded)
         "sha256": {
             "aarch64-apple-darwin": "185ac0631d3639da5ba09d6e50218af43efffa58383625dd070e6c2ecc11da65",
             "x86_64-apple-darwin": "bfb79474f078782104d6a80b21069f104eed8f7bac51d16a0216ca07d0b021e6",
@@ -70,6 +70,11 @@ def _verus_impl(module_ctx):
         release_tag = version_key
         known_hashes = {}
 
+    # Resolve nightly date for bundled Rust sysroot
+    rust_nightly = ""
+    if version_info:
+        rust_nightly = version_info.get("rust_nightly", "")
+
     # Create a repository for each supported platform
     platforms = _detect_platform(module_ctx)
     for platform in platforms:
@@ -81,6 +86,7 @@ def _verus_impl(module_ctx):
             version = release_tag,
             platform = platform,
             sha256 = sha256,
+            rust_nightly = rust_nightly,
         )
 
     # Create a hub repo that aliases to the correct platform-specific repo

--- a/verus/private/repo.bzl
+++ b/verus/private/repo.bzl
@@ -62,6 +62,12 @@ filegroup(
     srcs = glob(["builtin/**"]),
 )
 
+# Bundled Rust sysroot (librustc_driver and friends)
+filegroup(
+    name = "rust_sysroot_files",
+    srcs = glob(["rust_sysroot/**"]),
+)
+
 # All Verus files (for runfiles)
 filegroup(
     name = "all_files",
@@ -80,6 +86,7 @@ verus_toolchain_info(
     builtin_macros_dylib = ":builtin_macros_dylib",
     version = "{version}",
     rust_toolchain = "{rust_toolchain}",
+    rust_sysroot = ":rust_sysroot_files",
 )
 
 toolchain(
@@ -155,6 +162,26 @@ def _verus_release_impl(rctx):
     if result.return_code == 0:
         rust_toolchain = result.stdout.strip()
 
+    # Download the matching Rust sysroot (librustc_driver, libstd, etc.)
+    # rust_verify is dynamically linked against these and crashes without them.
+    rust_nightly = rctx.attr.rust_nightly
+    if rust_nightly:
+        # Download the rustc component from Rust's official dist
+        rustc_url = "https://static.rust-lang.org/dist/{date}/rustc-nightly-{triple}.tar.xz".format(
+            date = rust_nightly,
+            triple = platform,
+        )
+        rctx.download_and_extract(
+            url = rustc_url,
+            output = "rust_sysroot_tmp",
+            stripPrefix = "rustc-nightly-{triple}/rustc".format(triple = platform),
+        )
+        # Move to final location
+        rctx.execute(["mv", "rust_sysroot_tmp", "rust_sysroot"])
+    else:
+        # No nightly specified — create empty sysroot directory
+        rctx.execute(["mkdir", "-p", "rust_sysroot/lib"])
+
     # Write BUILD file
     rctx.file("BUILD.bazel", _BUILD_FILE_CONTENT.format(
         version = version,
@@ -176,6 +203,10 @@ verus_release = repository_rule(
         "sha256": attr.string(
             default = "",
             doc = "SHA-256 hash of the release zip (empty to skip verification)",
+        ),
+        "rust_nightly": attr.string(
+            default = "",
+            doc = "Nightly date (YYYY-MM-DD) for the Rust sysroot to bundle. Empty to skip.",
         ),
     },
     doc = "Downloads a pre-built Verus release binary from GitHub.",

--- a/verus/private/verus.bzl
+++ b/verus/private/verus.bzl
@@ -72,14 +72,13 @@ def _collect_dep_info(ctx):
 
     return extern_flags, transitive_stamps
 
-def _resolve_rust_sysroot(ctx):
-    """Resolve the Rust sysroot from rules_rust toolchain.
+def _resolve_rust_sysroot(verus_info):
+    """Get the bundled Rust sysroot from the Verus toolchain.
 
     Returns:
-        tuple of (sysroot_path string, all_files depset)
+        tuple of (sysroot_path string, sysroot_files depset)
     """
-    rust_tc = ctx.toolchains["@rules_rust//rust:toolchain_type"]
-    return rust_tc.sysroot, rust_tc.all_files
+    return verus_info.rust_sysroot_path, verus_info.rust_sysroot
 
 def _verus_verify_impl(ctx):
     """Run Verus verification on Rust source files."""
@@ -138,7 +137,7 @@ def _verus_verify_impl(ctx):
         )
 
     # Resolve Rust sysroot from rules_rust toolchain (hermetic)
-    rust_sysroot, rust_tc_files = _resolve_rust_sysroot(ctx)
+    rust_sysroot, rust_tc_files = _resolve_rust_sysroot(verus_info)
 
     # Add rules_rust toolchain files to inputs for sandbox access
     inputs = depset(
@@ -231,10 +230,7 @@ verus_library = rule(
         ),
         "_rule_kind": attr.string(default = "verus_library"),
     },
-    toolchains = [
-        "@rules_verus//verus:toolchain_type",
-        "@rules_rust//rust:toolchain_type",
-    ],
+    toolchains = ["@rules_verus//verus:toolchain_type"],
     doc = "Verify Rust source files with Verus. Produces a stamp file on success.",
 )
 
@@ -295,7 +291,7 @@ def _verus_test_impl(ctx):
         )
 
     # Resolve Rust sysroot from rules_rust toolchain (hermetic)
-    rust_sysroot, rust_tc_files = _resolve_rust_sysroot(ctx)
+    rust_sysroot, rust_tc_files = _resolve_rust_sysroot(verus_info)
 
     # Add rules_rust toolchain files to runfiles for sandbox access
     runfiles_list += rust_tc_files.to_list()
@@ -389,10 +385,7 @@ verus_test = rule(
         ),
         "_rule_kind": attr.string(default = "verus_test"),
     },
-    toolchains = [
-        "@rules_verus//verus:toolchain_type",
-        "@rules_rust//rust:toolchain_type",
-    ],
+    toolchains = ["@rules_verus//verus:toolchain_type"],
     test = True,
     doc = "Test target that runs Verus verification. Passes if all proofs verify.",
 )

--- a/verus/toolchain.bzl
+++ b/verus/toolchain.bzl
@@ -14,8 +14,27 @@ VerusToolchainInfo = provider(
         "builtin_macros_dylib": "File: The builtin_macros proc-macro library",
         "version": "String: Verus version",
         "rust_toolchain": "String: Rust toolchain version that rust_verify was built against (e.g., '1.93.0')",
+        "rust_sysroot": "depset of File: Bundled Rust sysroot files (librustc_driver, libstd)",
+        "rust_sysroot_path": "String: Path to the bundled Rust sysroot directory",
     },
 )
+
+def _find_sysroot_path(files):
+    """Find the sysroot directory path from the bundled files.
+
+    The sysroot is the directory containing lib/librustc_driver-*.
+    We look for any file under rust_sysroot/lib/ and derive the sysroot path.
+    """
+    for f in files:
+        # Find any file under the lib/ subdirectory
+        parts = f.path.split("/")
+        for i, part in enumerate(parts):
+            if part == "rust_sysroot" and i + 1 < len(parts) and parts[i + 1] == "lib":
+                return "/".join(parts[:i + 1])
+    # Fallback: if there are files, use the first file's directory
+    if files:
+        return files[0].path.rsplit("/", 1)[0]
+    return ""
 
 def _verus_toolchain_info_impl(ctx):
     """Create a VerusToolchainInfo provider for the toolchain."""
@@ -55,6 +74,8 @@ def _verus_toolchain_info_impl(ctx):
         builtin_macros_dylib = builtin_macros_dylib,
         version = ctx.attr.version,
         rust_toolchain = ctx.attr.rust_toolchain,
+        rust_sysroot = depset(ctx.files.rust_sysroot),
+        rust_sysroot_path = _find_sysroot_path(ctx.files.rust_sysroot),
     )
 
     return [
@@ -104,6 +125,10 @@ verus_toolchain_info = rule(
         "rust_toolchain": attr.string(
             default = "",
             doc = "Rust toolchain version that rust_verify was built against (e.g., '1.93.0')",
+        ),
+        "rust_sysroot": attr.label(
+            allow_files = True,
+            doc = "Bundled Rust sysroot files (librustc_driver, libstd)",
         ),
     },
     doc = "Provides Verus toolchain information",


### PR DESCRIPTION
## Summary

Bundle the matching Rust nightly sysroot (librustc_driver, libstd) inside the Verus toolchain repo, so consumers never need to know which nightly Verus was built against.

## Problem

`rust_verify` dynamically links against `librustc_driver` from `nightly-2025-11-21`. After PR #8 removed Rust toolchain registration, Verus crashes with `Abort trap: 6` because the sysroot isn't available.

## Fix

The `verus_release` repo rule now downloads the matching `rustc-nightly-{triple}.tar.xz` from `static.rust-lang.org` alongside the Verus binaries. The sysroot is bundled in the toolchain repo at `rust_sysroot/`.

Key changes:
- `extensions.bzl`: `_KNOWN_VERSIONS` gains `rust_nightly` date field, passed to `verus_release`
- `repo.bzl`: downloads rustc nightly component, bundles at `rust_sysroot/`
- `toolchain.bzl`: adds `rust_sysroot` (files) and `rust_sysroot_path` to provider
- `verus.bzl`: gets sysroot from Verus toolchain (not `@rules_rust//rust:toolchain_type`)
- `verus_library`/`verus_test` no longer depend on `@rules_rust//rust:toolchain_type`

**Consumer impact:** Zero. No toolchain registration needed, no rules_rust version conflicts.

## Test plan

- [ ] `bazel build //tools/verus-strip:verus-strip` (verus-strip still builds via crate_universe)
- [ ] `bazel test` with a verus_library target (sysroot resolves from bundled files)
- [ ] sigil builds without rules_rust version conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)