### PR TITLE
fix: download stable Rust sysroot matching rust_verify's librustc_driver

### DIFF
--- a/verus/extensions.bzl
+++ b/verus/extensions.bzl
@@ -10,7 +10,7 @@ load("//verus/private:repo.bzl", "verus_release")
 _KNOWN_VERSIONS = {
     "0.2026.02.15": {
         "tag": "0.2026.02.15.61aa1bf",
-        "rust_nightly": "2025-11-21",  # Nightly date for librustc_driver (auto-downloaded)
+        "rust_version": "1.93.0",  # Stable Rust version for librustc_driver (auto-downloaded)
         "sha256": {
             "aarch64-apple-darwin": "185ac0631d3639da5ba09d6e50218af43efffa58383625dd070e6c2ecc11da65",
             "x86_64-apple-darwin": "bfb79474f078782104d6a80b21069f104eed8f7bac51d16a0216ca07d0b021e6",
@@ -70,10 +70,10 @@ def _verus_impl(module_ctx):
         release_tag = version_key
         known_hashes = {}
 
-    # Resolve nightly date for bundled Rust sysroot
-    rust_nightly = ""
+    # Resolve Rust version for bundled sysroot (librustc_driver)
+    rust_version = ""
     if version_info:
-        rust_nightly = version_info.get("rust_nightly", "")
+        rust_version = version_info.get("rust_version", "")
 
     # Create a repository for each supported platform
     platforms = _detect_platform(module_ctx)
@@ -86,7 +86,7 @@ def _verus_impl(module_ctx):
             version = release_tag,
             platform = platform,
             sha256 = sha256,
-            rust_nightly = rust_nightly,
+            rust_version = rust_version,
         )
 
     # Create a hub repo that aliases to the correct platform-specific repo

--- a/verus/private/repo.bzl
+++ b/verus/private/repo.bzl
@@ -164,22 +164,27 @@ def _verus_release_impl(rctx):
 
     # Download the matching Rust sysroot (librustc_driver, libstd, etc.)
     # rust_verify is dynamically linked against these and crashes without them.
-    rust_nightly = rctx.attr.rust_nightly
-    if rust_nightly:
-        # Download the rustc component from Rust's official dist
-        rustc_url = "https://static.rust-lang.org/dist/{date}/rustc-nightly-{triple}.tar.xz".format(
-            date = rust_nightly,
+    # The version comes from version.json and must match exactly (hash in dylib name).
+    rust_version = rctx.attr.rust_version
+    if not rust_version and rust_toolchain:
+        # Fallback: use version extracted from version.json
+        rust_version = rust_toolchain
+    if rust_version:
+        rustc_url = "https://static.rust-lang.org/dist/rustc-{version}-{triple}.tar.xz".format(
+            version = rust_version,
             triple = platform,
         )
         rctx.download_and_extract(
             url = rustc_url,
             output = "rust_sysroot_tmp",
-            stripPrefix = "rustc-nightly-{triple}/rustc".format(triple = platform),
+            stripPrefix = "rustc-{version}-{triple}/rustc".format(
+                version = rust_version,
+                triple = platform,
+            ),
         )
-        # Move to final location
         rctx.execute(["mv", "rust_sysroot_tmp", "rust_sysroot"])
     else:
-        # No nightly specified — create empty sysroot directory
+        # No version known — create empty sysroot directory
         rctx.execute(["mkdir", "-p", "rust_sysroot/lib"])
 
     # Write BUILD file
@@ -204,9 +209,9 @@ verus_release = repository_rule(
             default = "",
             doc = "SHA-256 hash of the release zip (empty to skip verification)",
         ),
-        "rust_nightly": attr.string(
+        "rust_version": attr.string(
             default = "",
-            doc = "Nightly date (YYYY-MM-DD) for the Rust sysroot to bundle. Empty to skip.",
+            doc = "Rust version for the sysroot to bundle (e.g., '1.93.0'). Matches version.json.",
         ),
     },
     doc = "Downloads a pre-built Verus release binary from GitHub.",


### PR DESCRIPTION
## Summary

Fix the librustc_driver hash mismatch from #9 by downloading the **stable** Rust 1.93.0 sysroot instead of a nightly.

## Root cause

`rust_verify` links against `librustc_driver-35562f2af8f3540c.dylib`. PR #10 downloaded `nightly-2025-11-21` which has a different hash (`librustc_driver-4f10604dc9267822.dylib`). Verus 0.2026.02.15 was actually built against **stable Rust 1.93.0**, confirmed by:

- `version.json`: `"toolchain": "1.93.0-aarch64-apple-darwin"`
- `otool -L rust_verify`: `librustc_driver-35562f2af8f3540c.dylib`
- `rustc-1.93.0` dist: `librustc_driver-35562f2af8f3540c.dylib` (exact match)

## Fix

Download `rustc-1.93.0-{triple}.tar.xz` from `static.rust-lang.org/dist/` (stable, not nightly). Also adds a fallback: if `rust_version` isn't in `_KNOWN_VERSIONS`, uses the version extracted from `version.json` at repo-rule time.

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)