### PR TITLE
fix: cp -R trailing slash to merge rust-std correctly

### DIFF
--- a/verus/private/repo.bzl
+++ b/verus/private/repo.bzl
@@ -192,8 +192,8 @@ def _verus_release_impl(rctx):
             ),
         )
 
-        # Merge rust-std into sysroot (cp -R lib/rustlib into rust_sysroot/lib/rustlib)
-        rctx.execute(["cp", "-R", "rust_std_tmp/lib/rustlib", "rust_sysroot/lib/rustlib"])
+        # Merge rust-std into sysroot (trailing slash copies contents, not directory)
+        rctx.execute(["cp", "-R", "rust_std_tmp/lib/rustlib/", "rust_sysroot/lib/rustlib/"])
         rctx.execute(["rm", "-rf", "rust_std_tmp"])
     else:
         # No version known — create empty sysroot directory


### PR DESCRIPTION
## Problem

`cp -R rust_std_tmp/lib/rustlib rust_sysroot/lib/rustlib` creates nested `rustlib/rustlib/` when the target already exists (#14).

## Fix

Add trailing slash: `cp -R rust_std_tmp/lib/rustlib/ rust_sysroot/lib/rustlib/`

## Verified

Tested end-to-end with real Rust 1.93.0 dist downloads:
- `rust_sysroot/lib/librustc_driver-35562f2af8f3540c.dylib` (from rustc)
- `rust_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libstd-*.rlib` (from rust-std)
- No nested `rustlib/rustlib/`

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)