### PR TITLE
fix: allow_empty glob for fixtures + add regression tests

### DIFF
--- a/tools/verus-strip/BUILD.bazel
+++ b/tools/verus-strip/BUILD.bazel
@@ -21,6 +21,9 @@ rust_binary(
     visibility = ["//visibility:public"],
 )
 
+# Tests — only evaluated when building this repo directly (not via git_override).
+# Consumers only need the library and binary targets above.
+
 rust_test(
     name = "verus_strip_unit_test",
     crate = ":verus_strip_lib",
@@ -31,7 +34,10 @@ rust_test(
     srcs = ["tests/integration_test.rs"],
     deps = [":verus_strip_lib"],
     edition = "2024",
-    data = glob(["tests/fixtures/**"]),
+    data = glob(
+        ["tests/fixtures/**"],
+        allow_empty = True,
+    ),
     env = {
         "CARGO_MANIFEST_DIR": "tools/verus-strip",
     },

--- a/tools/verus-strip/tests/integration_test.rs
+++ b/tools/verus-strip/tests/integration_test.rs
@@ -138,3 +138,96 @@ fn strip_is_idempotent() {
         );
     }
 }
+
+/// Regression: verify that input files contain Verus constructs and stripped output does not.
+/// This catches regressions where the stripper stops removing certain constructs.
+#[test]
+fn stripped_output_has_no_verus_constructs() {
+    let dir = fixtures_dir();
+    let pairs = discover_fixture_pairs(&dir);
+
+    let verus_markers = &[
+        "verus!",
+        "use vstd",
+        "spec fn",
+        "proof fn",
+        "requires",
+        "ensures",
+        "#[verifier",
+        "#[trigger]",
+    ];
+
+    for (name, input_path, _) in &pairs {
+        let input = fs::read_to_string(input_path).unwrap();
+        let result = verus_strip::strip_file(&input);
+
+        assert!(
+            result.errors.is_empty(),
+            "{name}: strip produced parse errors: {:?}",
+            result.errors
+        );
+
+        // Input should contain at least some Verus constructs (otherwise it's a bad fixture)
+        let input_has_verus = verus_markers.iter().any(|m| input.contains(m));
+        assert!(
+            input_has_verus,
+            "{name}: input fixture has no Verus constructs — not a useful test"
+        );
+
+        // Stripped output must not contain any Verus constructs in code lines
+        // (comments may mention Verus keywords — that's fine)
+        let code_lines: Vec<&str> = result
+            .output
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty() && !t.starts_with("//")
+            })
+            .collect();
+        let code_text = code_lines.join("\n");
+
+        for marker in verus_markers {
+            assert!(
+                !code_text.contains(marker),
+                "{name}: stripped code still contains '{marker}':\n{}",
+                code_lines
+                    .iter()
+                    .filter(|l| l.contains(marker))
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }
+}
+
+/// Regression: verify that stripped output preserves runtime code.
+/// Checks that struct definitions, impl blocks, and runtime fn signatures survive stripping.
+#[test]
+fn stripped_output_preserves_runtime_code() {
+    let dir = fixtures_dir();
+
+    // Simple fixture: should preserve struct Counter, fn new, fn increment, fn value
+    let input = fs::read_to_string(dir.join("simple_input.rs")).unwrap();
+    let result = verus_strip::strip_file(&input);
+    assert!(result.errors.is_empty());
+
+    for expected in &["struct Counter", "fn new", "fn increment", "fn value"] {
+        assert!(
+            result.output.contains(expected),
+            "simple: stripped output missing '{expected}'"
+        );
+    }
+
+    // Complex fixture: should preserve struct Stack, fn new, fn push, fn pop, fn drain_all, fn is_empty
+    let input = fs::read_to_string(dir.join("complex_input.rs")).unwrap();
+    let result = verus_strip::strip_file(&input);
+    assert!(result.errors.is_empty());
+
+    for expected in &["struct Stack", "fn new", "fn push", "fn pop", "fn drain_all", "fn is_empty"] {
+        assert!(
+            result.output.contains(expected),
+            "complex: stripped output missing '{expected}'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fix #16: `allow_empty = True` on test data glob so `git_override` consumers don't fail
- Add regression tests verifying stripped output has no Verus constructs and preserves runtime code

## Tests added

| Test | What it checks |
|------|----------------|
| `stripped_output_has_no_verus_constructs` | No `verus!`, `vstd`, `spec fn`, `proof fn`, `requires`, `ensures`, `#[verifier]`, `#[trigger]` in code lines |
| `stripped_output_preserves_runtime_code` | Struct definitions and runtime fn signatures survive stripping |

All 13 tests pass locally (9 unit + 4 integration).

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)